### PR TITLE
Delete extraneous files from destination directory when deploying

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,7 +77,7 @@ else
 fi
 
 # Deploy via SSH
-rsync --rsh="ssh -v -p 22 -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no" -a --inplace --out-format="%n"  --exclude=".*" $SRC_PATH "$WPE_DESTINATION"
+rsync --rsh="ssh -v -p 22 -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no" --archive --inplace --delete --out-format="%n"  --exclude=".*" $SRC_PATH "$WPE_DESTINATION"
 
 # Clear cache 
 ssh -v -p 22 -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no $WPE_SSH_USER "cd sites/${WPE_ENV_NAME} && wp page-cache flush"


### PR DESCRIPTION
This ensures that files that aren't in the source directory are deleted from the destination.

The `--delete` option in rsync "deletes extraneous files from dest dirs." Without this argument, files in the destination directory that are not present in the source directory (e.g., files that were deleted, or are no longer under version control) would still be in the destination directory after syncing. This wouldn't be a true 'sync' or 'deploy,' then, because old files would be sticking around. This is unexpected behavior for users who think they source directory being deployed will completely overwrite the destination.

(This PR also expands the `-a` rsync flag to `--archive` to make the flag clearer and match the flags around it.)