### PR TITLE
[CICD-29] Stop erroneous build failures due to attempt to rsync mu-plugin subdirectories

### DIFF
--- a/exclude.txt
+++ b/exclude.txt
@@ -53,7 +53,7 @@ wp-content/mu-plugins/force-strong-passwords*
 wp-content/mu-plugins/wpengine-common*
 wp-content/mu-plugins/wpe-wp-sign-on-plugin*
 wp-content/mu-plugins/wpe-elasticpress-autosuggest-logger*
-wp-content/mu-plugins/wpe-cache-plugin*
+wp-content/mu-plugins/wpe-cache-plugin/*
 wp-content/mysql.sql
 
 # Local specific

--- a/exclude.txt
+++ b/exclude.txt
@@ -54,6 +54,7 @@ wp-content/mu-plugins/wpengine-common*
 wp-content/mu-plugins/wpe-wp-sign-on-plugin*
 wp-content/mu-plugins/wpe-elasticpress-autosuggest-logger*
 wp-content/mu-plugins/wpe-cache-plugin/*
+wp-content/mu-plugins/wpe-cache-plugin/
 wp-content/mysql.sql
 
 # Local specific

--- a/exclude.txt
+++ b/exclude.txt
@@ -54,7 +54,7 @@ wp-content/mu-plugins/wpengine-common*
 wp-content/mu-plugins/wpe-wp-sign-on-plugin*
 wp-content/mu-plugins/wpe-elasticpress-autosuggest-logger*
 wp-content/mu-plugins/wpe-cache-plugin/*
-wp-content/mu-plugins/wpe-cache-plugin/
+wp-content/mu-plugins/wpe-cache-plugin*
 wp-content/mysql.sql
 
 # Local specific


### PR DESCRIPTION
# JIRA Ticket

[CICD-29](https://wpengine.atlassian.net/browse/CICD-29)

## What Are We Doing Here

When adding all install files to a repository, the GHA build was failing due to rsync attempting to update the mu-plugin/wpe-cache-plugin subdirectories:

```
rsync: failed to set times on "/home/wpe-user/sites/dscicdtest1/wp-content/mu-plugins/wpe-cache-plugin": Operation not permitted (1)
rsync: failed to set times on "/home/wpe-user/sites/dscicdtest1/wp-content/mu-plugins/wpe-cache-plugin/css": Operation not permitted (1)
rsync: failed to set times on "/home/wpe-user/sites/dscicdtest1/wp-content/mu-plugins/wpe-cache-plugin/js": Operation not permitted (1)
rsync: failed to set times on "/home/wpe-user/sites/dscicdtest1/wp-content/mu-plugins/wpe-cache-plugin/js/components": Operation not permitted (1)
rsync: failed to set times on "/home/wpe-user/sites/***/wp-content/mu-plugins/wpe-cache-plugin/js/dist": Operation not permitted (1)
rsync: failed to set times on "/home/wpe-user/sites/***/wp-content/mu-plugins/wpe-cache-plugin/js/services": Operation not permitted (1)
rsync: failed to set times on "/home/wpe-user/sites/***/wp-content/mu-plugins/wpe-cache-plugin/js/utils": Operation not permitted (1)
rsync: failed to set times on "/home/wpe-user/sites/***/wp-content/mu-plugins/wpe-cache-plugin/security": Operation not permitted (1)
rsync: failed to set times on "/home/wpe-user/sites/***/wp-content/mu-plugins/wpe-cache-plugin/view": Operation not permitted (1)
```

This PR fixes the excludes paths to ensure this doesn't happen.