### PR TITLE
[CICD-47] Add a basic e2e test

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -1,0 +1,40 @@
+name: Test e2e Deploy to WP Engine
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+  run_action:
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.deploy.outputs.status }}
+    steps: 
+      - uses: actions/checkout@v3
+      - name: Bump test plugin version number
+        run: sed -i 's/0.0.1/0.0.2/' tests/data/plugins/test-plugin/test-plugin.php
+      - name: GitHub Action Deploy to WP Engine
+        id: deploy
+        uses: ./
+        with:
+          # Deploy vars 
+          WPE_SSHG_KEY_PRIVATE: ${{ secrets.WPE_SSHG_KEY_PRIVATE }} 
+          WPE_ENV: ghae2e
+          # Deploy Options
+          SRC_PATH: "tests/data/plugins/test-plugin"
+          REMOTE_PATH: "wp-content/plugins/"
+          PHP_LINT: TRUE
+          FLAGS: -r --backup --backup-dir=/tmp --itemize-changes
+          SCRIPT: "tests/data/post-deploy/test-plugin.sh"
+          CACHE_CLEAR: TRUE
+  validate_result:
+    runs-on: ubuntu-latest
+    needs: run_action
+    steps:
+      - name: Validate deploy results
+        run: |
+          [ ${{needs.run_action.outputs.status}} = "pass" ] || exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,7 +92,7 @@ ssh -nNf -v -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no -o Contr
 
 echo "!!! MASTER SSH CONNECTION ESTABLISHED !!!"
 #rsync 
-# rsync --rsh="ssh -v -p 22 -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no -o 'ControlPath=$SSH_PATH/ctl/%C'" $INPUT_FLAGS --exclude-from='/exclude.txt' $SRC_PATH "$WPE_DESTINATION"
+rsync --rsh="ssh -v -p 22 -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no -o 'ControlPath=$SSH_PATH/ctl/%C'" $INPUT_FLAGS --exclude-from='/exclude.txt' $SRC_PATH "$WPE_DESTINATION"
 
 # post deploy script and cache clear
 if [[ -n ${SCRIPT} || -n ${CACHE_CLEAR} ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,7 +92,7 @@ ssh -nNf -v -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no -o Contr
 
 echo "!!! MASTER SSH CONNECTION ESTABLISHED !!!"
 #rsync 
-rsync --rsh="ssh -v -p 22 -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no -o 'ControlPath=$SSH_PATH/ctl/%C'" $INPUT_FLAGS --exclude-from='/exclude.txt' $SRC_PATH "$WPE_DESTINATION"
+# rsync --rsh="ssh -v -p 22 -i ${WPE_SSHG_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no -o 'ControlPath=$SSH_PATH/ctl/%C'" $INPUT_FLAGS --exclude-from='/exclude.txt' $SRC_PATH "$WPE_DESTINATION"
 
 # post deploy script and cache clear
 if [[ -n ${SCRIPT} || -n ${CACHE_CLEAR} ]]; then

--- a/tests/data/plugins/test-plugin/test-plugin.php
+++ b/tests/data/plugins/test-plugin/test-plugin.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Plugin Name: Deploy WordPress to WP Engine - e2e Test
+ * Plugin URI: https://github.com/wpengine/github-action-wpe-site-deploy
+ * Description: Sample code to test the Site Deployment GitHub Action by WP Engine.
+ * Version: 0.0.1
+ */
+ 
+ add_action('init', 'register_my_cpt');
+
+ function register_my_cpt() {
+    register_post_type('my-cpt', array(
+        'public' => true
+    ));
+ }

--- a/tests/data/post-deploy/test-plugin.sh
+++ b/tests/data/post-deploy/test-plugin.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+BACKUP_DIR=/tmp
+PLUGINS_DIR=wp-content/plugins
+PLUGIN_NAME=test-plugin
+
+cleanup() {
+    rm tests/data/post-deploy/test-plugin.sh
+}
+trap cleanup EXIT
+
+# Get the the new plugin version
+AFTER_PLUGIN_VERSION=$(wp plugin get $PLUGIN_NAME | sed -n "/version/p" | cut -f2)
+echo "New test plugin version: $AFTER_PLUGIN_VERSION"
+
+# Revert to backup created by rsync if it exists
+if [ -d $BACKUP_DIR/$PLUGIN_NAME ]; then 
+    rm -rf $PLUGINS_DIR/$PLUGIN_NAME && mv $BACKUP_DIR/$PLUGIN_NAME $PLUGINS_DIR/
+fi
+
+# Get the old plugin version
+BEFORE_PLUGIN_VERSION=$(wp plugin get $PLUGIN_NAME | sed -n "/version/p" | cut -f2)
+echo "Old test plugin version: $BEFORE_PLUGIN_VERSION"
+
+# Check that the expected update was made
+if [ -z "$BEFORE_PLUGIN_VERSION" ] || [ -z "$AFTER_PLUGIN_VERSION" ] || [ "$BEFORE_PLUGIN_VERSION" = "$AFTER_PLUGIN_VERSION" ]; then
+    echo "Failure: Test plugin was not updated!"
+    echo "::set-output name=status::fail"
+else
+    echo "Success: Test plugin successfully updated from $BEFORE_PLUGIN_VERSION to $AFTER_PLUGIN_VERSION!"
+    echo "::set-output name=status::pass"
+fi


### PR DESCRIPTION
# JIRA Ticket

[CICD-47](https://wpengine.atlassian.net/browse/CICD-47)

## What Are We Doing Here

Introduces a workflow that runs an end-to-end test of the action.

- Pull requests targeting `main` and pushes to `main` will trigger the workflow.
- Uses the local copy of the action. If a PR makes changes to the action, those changes are included in the test.

The objective of the test is to bump the version of a minimal WordPress plugin, deploy it to the remote, and validate that the remote plugin version was updated successfully. The test also resets the remote copy of the plugin to its pre-deploy state.

## Testing

Commit d8dc96e introduces a breaking change to the action and results in the e2e test failing. The next commit reverts the breaking change and shows that the test passes again.
