### PR TITLE
Update Readme with working exclude example and ensure exclude.txt doesn't delete  wpe-cache-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ jobs:
         SRC_PATH: "wp-content/themes/genesis-child-theme/"
         REMOTE_PATH: "wp-content/themes/genesis-child-theme/"
         PHP_LINT: TRUE
-        FLAGS: -azvr --inplace --delete --exclude=".*" --exclude-from=ignorefile.txt
+        FLAGS: -azvr --inplace --delete --exclude=file1 --exclude=file2 --exclude=wp-content/mu-plugins/local-plugin --exclude-from=ignorefile.txt
         SCRIPT: "path/yourscript.sh"
         CACHE_CLEAR: TRUE
 ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ jobs:
         SRC_PATH: "wp-content/themes/genesis-child-theme/"
         REMOTE_PATH: "wp-content/themes/genesis-child-theme/"
         PHP_LINT: TRUE
-        FLAGS: -azvr --inplace --delete --exclude=file1 --exclude=file2 --exclude=wp-content/mu-plugins/local-plugin --exclude-from=ignorefile.txt
+        FLAGS: -azvr --inplace --delete --exclude=".*"  --exclude=wp-content/mu-plugins/local-plugin --exclude-from=ignorefile.txt
         SCRIPT: "path/yourscript.sh"
         CACHE_CLEAR: TRUE
 ```

--- a/exclude.txt
+++ b/exclude.txt
@@ -53,7 +53,6 @@ wp-content/mu-plugins/force-strong-passwords*
 wp-content/mu-plugins/wpengine-common*
 wp-content/mu-plugins/wpe-wp-sign-on-plugin*
 wp-content/mu-plugins/wpe-elasticpress-autosuggest-logger*
-wp-content/mu-plugins/wpe-cache-plugin/*
 wp-content/mu-plugins/wpe-cache-plugin*
 wp-content/mysql.sql
 


### PR DESCRIPTION
# JIRA Ticket

Sorry no ticket just a helpful bystander.

## What Are We Doing Here

The purpose of this PR is to address 2 issues:
1. The new README documentation provides a working example to exclude deleting two files and a directory. The existing example is not helpful as it includes quote marks and appears to intend to exclude everything? After thorough testing, troubleshooting, and reaching out to support -- I was able to determine that quote marks are not actually supported.
2. The current exclude.txt wasn't actually excluding the wpe-cache-plugin, both the directory and the php file were being deleted. The included update appears to fix this issue.