### PR TITLE
Add versioning information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,6 @@ jobs:
 
 ## Versioning
 
-We follow [SemVer](https://semver.org/) and [GitHub's action versioning recommendations](https://github.com/actions/toolkit/blob/01e1ff7bc04e1c57c980a0d1530478a5b60cf812/docs/action-versioning.md) for maintaining major, minor, and patch [version tags](https://github.com/wpengine/github-action-wpe-site-deploy/tags). Major tags (e.g. `v1`) are updated to track the latest major version and minor tags (e.g. `v1.1`) are updated to track the latest minor version. Patch tags (e.g. `v1.1.1`) are never updated.
+We follow [SemVer](https://semver.org/) and [GitHub's action versioning recommendations](https://github.com/actions/toolkit/blob/01e1ff7bc04e1c57c980a0d1530478a5b60cf812/docs/action-versioning.md) for maintaining major, minor, and patch [version tags](https://github.com/wpengine/github-action-wpe-site-deploy/tags). Patch tags (e.g. `v1.1.1`) are created for each release and will not move once created. Major tags (e.g. `v1`) and minor tags (e.g. `v1.1`) will be updated to track their respective latest versions.
 
 We recommend binding this action to the latest major tag so that you will receive backwards compatible updates.

--- a/README.md
+++ b/README.md
@@ -120,3 +120,9 @@ jobs:
 * [Storing secrets in GitHub repositories](https://docs.github.com/en/actions/reference/encrypted-secrets)
 * It is recommended to leverage one of [WP Engine's .gitignore templates.](https://wpengine.com/support/git/#Add_gitignore)
 * This action excludes several files and directories from the deploy by default. See the [exclude.txt](https://github.com/wpengine/github-action-wpe-site-deploy/blob/main/exclude.txt) for reference.
+
+## Versioning
+
+We follow [SemVer](https://semver.org/) and [GitHub's action versioning recommendations](https://github.com/actions/toolkit/blob/01e1ff7bc04e1c57c980a0d1530478a5b60cf812/docs/action-versioning.md) for maintaining major, minor, and patch [version tags](https://github.com/wpengine/github-action-wpe-site-deploy/tags). Major tags (e.g. `v1`) are updated to track the latest major version and minor tags (e.g. `v1.1`) are updated to track the latest minor version. Patch tags (e.g. `v1.1.1`) are never updated.
+
+We recommend binding this action to the latest major tag so that you will receive backwards compatible updates.


### PR DESCRIPTION
# JIRA Ticket

n/a

## What Are We Doing Here

Adds a section to the README describing how we version so that users can make informed decisions about what version to bind to.
