### PR TITLE
[CICD-77] Prevent plugin and theme conflicts from adversely affecting cache clear

### DIFF
--- a/.changeset/good-pears-play.md
+++ b/.changeset/good-pears-play.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/github-action-wpe-site-deploy": patch
+---
+
+Prevent plugin and theme conflicts from adversely affecting cache clear

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,7 +80,7 @@ fi
 
 # post deploy cache clear
 if [ "${INPUT_CACHE_CLEAR^^}" == "TRUE" ]; then
-    CACHE_CLEAR="&& wp page-cache flush"
+    CACHE_CLEAR="&& wp --skip-plugins --skip-themes page-cache flush"
   elif [ "${INPUT_CACHE_CLEAR^^}" == "FALSE" ]; then
       CACHE_CLEAR=""
   else echo "CACHE_CLEAR must be TRUE or FALSE only... Cache not cleared..."  && exit 1;


### PR DESCRIPTION
# JIRA Ticket

[CICD-77](https://wpengine.atlassian.net/browse/CICD-77)

## What Are We Doing Here

Clearing page cache relies on WP CLI. When we call `wp page-cache flush`, the WP CLI bootstrap process loads all of WordPress, including active plugins and themes. If any of the loaded plugins or themes contain errors, those will cause the page cache clear to either fail or hang indefinitely. This results in a "failed" deploy status even if the code was successfully updated.

We don't need to load plugins and themes to successfully clear cache, so we can set flags to ignore them.
