### PR TITLE
Add CDN cache clearing to the CACHE_CLEAR flag

### DIFF
--- a/.changeset/cdn-cache-clear.md
+++ b/.changeset/cdn-cache-clear.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/github-action-wpe-site-deploy": minor
+---
+
+Add CDN cache clearing ability to the CACHE_CLEAR flag.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ jobs:
 | `PHP_LINT` | bool | Set to TRUE to execute a php lint on your branch pre-deployment. Default is `FALSE`. |
 | `FLAGS` | string | Set optional rsync flags such as `--delete` or `--exclude-from`. The example is excluding paths specified in a `.deployignore` file in the root of the repo. This action defaults to a non-destructive deploy using the flags in the example above. <br /><br />_Caution: Setting custom rsync flags replaces the default flags provided by this action. Consider also adding the `-azvr` flags as needed.<br /> `-a` preserves symbolic links, timestamps, user permissions and ownership.<br /> `-z` is for compression <br /> `-v` is for verbose output<br /> `-r` is for recursive directory scanning_|
 | `SCRIPT` | string | Remote bash file to execute post-deploy. This can include WP_CLI commands for example. Path is relative to the WP root and file executes on remote. This file can be included in your repo, or be a persistent file that lives on your server.  |
-| `CACHE_CLEAR` | bool | Optionally clear cache post deploy. This takes a few seconds. Default is TRUE. |
+| `CACHE_CLEAR` | bool | Optionally clear page and CDN cache post deploy. This takes a few seconds. Default is TRUE. |
 
 
 ### Further reading

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,7 +80,7 @@ fi
 
 # post deploy cache clear
 if [ "${INPUT_CACHE_CLEAR^^}" == "TRUE" ]; then
-    CACHE_CLEAR="&& wp --skip-plugins --skip-themes page-cache flush"
+    CACHE_CLEAR="&& wp --skip-plugins --skip-themes page-cache flush && wp cdn-cache flush"
   elif [ "${INPUT_CACHE_CLEAR^^}" == "FALSE" ]; then
       CACHE_CLEAR=""
   else echo "CACHE_CLEAR must be TRUE or FALSE only... Cache not cleared..."  && exit 1;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,7 +80,7 @@ fi
 
 # post deploy cache clear
 if [ "${INPUT_CACHE_CLEAR^^}" == "TRUE" ]; then
-    CACHE_CLEAR="&& wp --skip-plugins --skip-themes page-cache flush && wp cdn-cache flush"
+    CACHE_CLEAR="&& wp --skip-plugins --skip-themes page-cache flush && wp --skip-plugins --skip-themes cdn-cache flush"
   elif [ "${INPUT_CACHE_CLEAR^^}" == "FALSE" ]; then
       CACHE_CLEAR=""
   else echo "CACHE_CLEAR must be TRUE or FALSE only... Cache not cleared..."  && exit 1;


### PR DESCRIPTION
# JIRA Ticket

[CICD-28](https://wpengine.atlassian.net/browse/CICD-28)

## What Are We Doing Here

This PR adds CDN cache clearing functionality to the `CACHE_CLEAR` flag.

From e2e test logs:
```
debug1: Sending command: cd sites/ghae2e && sh tests/data/post-deploy/test-plugin.sh && wp --skip-plugins --skip-themes page-cache flush && wp --skip-plugins --skip-themes cdn-cache flush
debug1: mux_client_request_session: master session id: 2
New test plugin version: 0.0.2
Old test plugin version: 0.0.1
Success: Test plugin successfully updated from 0.0.1 to 0.0.2!
Success: Page Cache was flushed.
Success: CDN Cache was flushed.
```