### PR TITLE
[CICD-24] Use hosted dockerfile image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM wpengine/gha:v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,1 @@
-FROM instrumentisto/rsync-ssh:alpine3.13-r4
-LABEL "com.github.actions.name"="GitHub Action for WP Engine Site Deploy"
-LABEL "com.github.actions.description"="An action to deploy your repository to WP Engine via the SSH Gateway"
-LABEL "com.github.actions.icon"="upload-cloud"
-LABEL "com.github.actions.color"="blue"
-LABEL "repository"="http://github.com/wpengine/github-action-wpe-site-deploy"
-LABEL "maintainer"="Alex Zuniga <alex.zuniga@wpengine.com>"
-RUN apk add bash php
-ADD entrypoint.sh /entrypoint.sh
-ADD exclude.txt /exclude.txt
-ENTRYPOINT ["/entrypoint.sh"]
+FROM wpengine/gha:v1

--- a/action.yml
+++ b/action.yml
@@ -46,4 +46,4 @@ inputs:
 
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: docker://wpengine/gha:v1

--- a/action.yml
+++ b/action.yml
@@ -46,4 +46,4 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://wpengine/gha:v1
+  image: docker://wpengine/gha:latest

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,0 +1,11 @@
+FROM instrumentisto/rsync-ssh:alpine3.13-r4
+LABEL "com.github.actions.name"="GitHub Action for WP Engine Site Deploy"
+LABEL "com.github.actions.description"="An action to deploy your repository to WP Engine via the SSH Gateway"
+LABEL "com.github.actions.icon"="upload-cloud"
+LABEL "com.github.actions.color"="blue"
+LABEL "repository"="http://github.com/wpengine/github-action-wpe-site-deploy"
+LABEL "maintainer"="Alex Zuniga <alex.zuniga@wpengine.com>"
+RUN apk add bash php
+ADD entrypoint.sh /entrypoint.sh
+ADD exclude.txt /exclude.txt
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
# JIRA Ticket

[CICD-24](https://wpengine.atlassian.net/browse/CICD-24)

## What Are We Doing Here

Building and hosting image on WPE docker hub, then calling the hosted image instead of building it every time. 


**Original: Avg 11-14 seconds**
(Build Docker Container on the fly)
![cicd-24-docker-container-build-v3-1-1](https://user-images.githubusercontent.com/26469099/184686846-4a2b80c2-d7b9-4b1f-ad82-fa20c3dfe14c.png)

**New: 4 seconds :tada:** 
(Build Docker Container from Hosted Docker Image)
![cicd-24-docker-container-build-cicd-24-branch](https://user-images.githubusercontent.com/26469099/184686847-4882c690-57f5-4a6f-99ac-e6214ddb6dcf.png)

**NewNew: 1 second 🐎**
(Pull Docker Image directly from within action.yml)
![cicd-24-load-docker-image-directly](https://user-images.githubusercontent.com/26469099/184727267-347a840c-eca7-4dcf-90ec-f6d23250bff5.png)

