### PR TITLE
[CICD-68] Add e2e cron schedule with Slack integration on failure

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -1,5 +1,7 @@
 name: Test e2e Deploy to WP Engine
 on:
+  schedule:
+    - cron: '*/5 * * * *'
   push:
     branches:
       - main
@@ -38,3 +40,12 @@ jobs:
       - name: Validate deploy results
         run: |
           [ ${{needs.run_action.outputs.status}} = "pass" ] || exit 1
+      - name: Notify slack on failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: status-github-action
+          status: FAILED
+          color: danger

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           [ ${{needs.run_action.outputs.status}} = "pass" ] || exit 1
       - name: Notify slack on failure
-        if: success()
+        if: success() && github.ref == 'refs/heads/main'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           [ ${{needs.run_action.outputs.status}} = "pass" ] || exit 1
       - name: Notify slack on failure
-        if: failure()
+        if: success()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1


### PR DESCRIPTION
# JIRA Ticket

[CICD-68](https://wpengine.atlassian.net/browse/CICD-68)

## What Are We Doing Here

This PR adds a cron schedule to to the e2e testing action, as well as Slack integration using a 3rd party action. This would allow us to monitor the health of the GHA by triggering our e2e tests every 5 minutes. On failure, it will notify the corresponding monitoring Slack channel #status-github-action.
