### PR TITLE
Set Slack notification to trigger on failure

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           [ ${{needs.run_action.outputs.status}} = "pass" ] || exit 1
       - name: Notify slack on failure
-        if: success() && github.ref == 'refs/heads/main'
+        if: failure() && github.ref == 'refs/heads/main'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1


### PR DESCRIPTION
# JIRA Ticket

[CICD-68](https://wpengine.atlassian.net/browse/CICD-68)

## What Are We Doing Here

Previous PR set Slack notifications to trigger on successes to test the integration. This PR sets Slack notifications to be triggered on failure as originally planned.
