### PR TITLE
[CICD-24] Split docker image to separate exclude.txt and entrypoint script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,24 @@ Thanks for your interest in contributing! There are several ways to get involved
 - Discuss open [issues](https://github.com/wpengine/github-action-wpe-site-deploy/issues).
 - Submit [bugs](https://github.com/wpengine/github-action-wpe-site-deploy/issues/new?assignees=&labels=&template=bug_report.md&title=) and help us verify fixes as they are checked in.
 - Open or participate in [discussions](https://github.com/wpengine/github-action-wpe-site-deploy/discussions) regarding feature requests.
+
+### Managing the Dockerfile & Docker Image
+
+The bulk of the Dockerfile is hosted as a Docker image on DockerHub. The image is originally built locally from a Dockerfile located in the Dockerfiles directory: `Dockerfiles/Dockerfile`. It is then also re-built automatically via automated docker build configurations.
+
+Another Dockerfile at the project root imports the requested version (via Docker tag) from DockerHub and adds any customizations to the image as necessary.
+
+#### Updating the Docker Image
+The Docker image will rarely need to be updated. The Dockerfile is updated when a new version of the project is released.
+
+- Build the docker image locally:
+`docker build --no-cache -t wpengine/gha:v1 . `
+
+- Push the image to DockerHub:
+`docker push wpengine/gha:v1`
+
+Once the hosted Docker image is updated, it will need to be manually imported and/or updated in the project root Dockerfile when the image version or tag changes.
+- Update the root Docker file for the project with the latest version of the Docker Image. i.e.:
+`FROM wpengine/gha:v1`
+
+_*Process will be automated in the future._

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM instrumentisto/rsync-ssh:alpine3.13-r4
-LABEL "com.github.actions.name"="GitHub Action for WP Engine Site Deploy"
-LABEL "com.github.actions.description"="An action to deploy your repository to WP Engine via the SSH Gateway"
-LABEL "com.github.actions.icon"="upload-cloud"
-LABEL "com.github.actions.color"="blue"
-LABEL "repository"="http://github.com/wpengine/github-action-wpe-site-deploy"
-LABEL "maintainer"="Alex Zuniga <alex.zuniga@wpengine.com>"
-RUN apk add bash php
+FROM wpengine/gha:v1
 ADD entrypoint.sh /entrypoint.sh
 ADD exclude.txt /exclude.txt
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,0 +1,12 @@
+# Build and push a new to Docker Hub when changes are made to this file.
+# - Import the image to the main Dockerfile via DockerHub: https://hub.docker.com/repository/docker/wpengine/gha
+# - Add any additional dockerfiles to the main Dockerfile after the import FROM wpengine/gha:v1
+
+FROM instrumentisto/rsync-ssh:alpine3.13-r4
+LABEL "com.github.actions.name"="GitHub Action for WP Engine Site Deploy"
+LABEL "com.github.actions.description"="An action to deploy your repository to WP Engine via the SSH Gateway"
+LABEL "com.github.actions.icon"="upload-cloud"
+LABEL "com.github.actions.color"="blue"
+LABEL "repository"="http://github.com/wpengine/github-action-wpe-site-deploy"
+LABEL "maintainer"="Alex Zuniga <alex.zuniga@wpengine.com>"
+RUN apk add bash php


### PR DESCRIPTION
# JIRA Ticket

[CICD-24](https://wpengine.atlassian.net/browse/CICD-24)

## What Are We Doing Here

Building and hosting image on WPE docker hub, then calling the hosted image instead of building it every time. 


**Original: Avg 11-14 seconds**
(Build Docker Container on the fly)
![cicd-24-docker-container-build-v3-1-1](https://user-images.githubusercontent.com/26469099/184686846-4a2b80c2-d7b9-4b1f-ad82-fa20c3dfe14c.png)

**New: 4 seconds :tada:** 
(Build Docker Container from Hosted Docker Image)
![cicd-24-docker-container-build-cicd-24-branch](https://user-images.githubusercontent.com/26469099/184686847-4882c690-57f5-4a6f-99ac-e6214ddb6dcf.png)

**NewNew: 1 second 🐎**
(Pull Docker Image directly from within action.yml)
![cicd-24-load-docker-image-directly](https://user-images.githubusercontent.com/26469099/184727267-347a840c-eca7-4dcf-90ec-f6d23250bff5.png)

**NewSPLIT: 19 seconds? 😲 🐳 "
(Build Docker Container from Hosted Docker Image, but split to add in exclude.txt and entrypoint script afterwards)

![Screen Shot 2022-08-29 at 6 46 56 PM](https://user-images.githubusercontent.com/26469099/187318204-6052c1b4-2105-4020-af4d-7a177e5f1141.png)
