### PR TITLE
[CICD-24] Improve performance by utilizing pre-built Docker Image.

### DIFF
--- a/.changeset/loud-penguins-flash.md
+++ b/.changeset/loud-penguins-flash.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/github-action-wpe-site-deploy": patch
+---
+
+Improve performance by utilizing pre-built Docker Image.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,3 +27,28 @@ We use [Changesets](https://github.com/changesets/changesets) to automate versio
 3. Approve, then "Squash and merge" the PR into `main`.
 
 Merging the versioning PR will run a workflow that creates or updates all necessary tags. It will also create a new release in GitHub.
+
+## Managing the Dockerfile & Docker Image
+
+The base of the `Dockerfile` is hosted as a Docker image on DockerHub. The image is originally built locally from `Dockerfiles/Dockerfile` and pushed up to DockerHub.
+
+The main `Dockerfile` at the project root imports the `wpengine/gha:base-stable` hosted image from DockerHub. Customizations to the image should be added below the base image for code that is updated more frequently, such as:
+- entrypoint.sh
+- exclude.txt
+
+All other customizations that are updated less frequently, or managed by 3rd parties, should be added to the `base-stable` image. Rebuild and push the image to DockerHub to update the image.
+
+## Updating the Docker Image
+The `base-stable` Docker Image will rarely need to be updated, however it may be necessary to update it manually* from time to time.
+
+- Build the docker image locally:
+`docker build --no-cache -t wpengine/gha:base-stable Dockerfiles`
+
+- Push the image to DockerHub:
+`docker push wpengine/gha:base-stable`
+
+Once the hosted Docker image is updated, it will need to be imported (or updated) on the main project `Dockerfile`. If the Dockerhub tag name (image version) has changed, update the existing line in the project root `Dockerfile` to match the new tag name.
+- Update the root Docker file for the project with the latest version of the Docker Image:tagname. i.e.:
+`FROM wpengine/gha:base-stable`
+
+_*TO DO: Process will be automated in the future._

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-# Build this manually from Dockerfiles/Dockerfile and push to DockerHub to rebuild changes.
-# TODO: Automate this process.
+# Pull the base image from DockerHub. 
+# If you need to make changes to the base image, rebuild it manually from `Dockerfiles/Dockerfile` and push to DockerHub.
+# TODO: Automate this process to track stable tags and custom branch tags(based on regex).
 FROM wpengine/gha:base-stable
 
-# Add any additional dockerfile commands after the import FROM wpengine/gha:base-stable
+# Add any additional directives after the import FROM wpengine/gha:base-stable
 ADD entrypoint.sh /entrypoint.sh
 ADD exclude.txt /exclude.txt
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM instrumentisto/rsync-ssh:alpine3.13-r4
-LABEL "com.github.actions.name"="GitHub Action for WP Engine Site Deploy"
-LABEL "com.github.actions.description"="An action to deploy your repository to WP Engine via the SSH Gateway"
-LABEL "com.github.actions.icon"="upload-cloud"
-LABEL "com.github.actions.color"="blue"
-LABEL "repository"="http://github.com/wpengine/github-action-wpe-site-deploy"
-LABEL "maintainer"="Alex Zuniga <alex.zuniga@wpengine.com>"
-RUN apk add bash php
+# Build this manually from Dockerfiles/Dockerfile and push to DockerHub to rebuild changes.
+# TODO: Automate this process.
+FROM wpengine/gha:base-stable
+
+# Add any additional dockerfile commands after the import FROM wpengine/gha:base-stable
 ADD entrypoint.sh /entrypoint.sh
 ADD exclude.txt /exclude.txt
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,0 +1,12 @@
+# Build and push a new to Docker Hub when changes are made to this file.
+# - Import the image to the main Dockerfile via DockerHub: https://hub.docker.com/repository/docker/wpengine/gha
+# - Add any additional dockerfiles to the main Dockerfile after the import FROM wpengine/gha:v1
+
+FROM instrumentisto/rsync-ssh:alpine3.13-r4
+LABEL "com.github.actions.name"="GitHub Action for WP Engine Site Deploy"
+LABEL "com.github.actions.description"="An action to deploy your repository to WP Engine via the SSH Gateway"
+LABEL "com.github.actions.icon"="upload-cloud"
+LABEL "com.github.actions.color"="blue"
+LABEL "repository"="http://github.com/wpengine/github-action-wpe-site-deploy"
+LABEL "maintainer"="Alex Zuniga <alex.zuniga@wpengine.com>"
+RUN apk add bash php

--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,6 +1,6 @@
-# Build and push a new to Docker Hub when changes are made to this file.
-# - Import the image to the main Dockerfile via DockerHub: https://hub.docker.com/repository/docker/wpengine/gha
-# - Add any additional dockerfiles to the main Dockerfile after the import FROM wpengine/gha:v1
+# Build and push a new image to Docker Hub when changes are made to this file.
+# - Import the base Docker image hosted in DockerHub: https://hub.docker.com/repository/docker/wpengine/gha `FROM wpengine/gha:base-stable`
+# - Customizations to the image should be added for code that is updated more frequently below the base image in github-action-wpe-site-deploy/Dockerfile.
 
 FROM instrumentisto/rsync-ssh:alpine3.13-r4
 LABEL "com.github.actions.name"="GitHub Action for WP Engine Site Deploy"


### PR DESCRIPTION
# JIRA Ticket

[CICD-24](https://wpengine.atlassian.net/browse/CICD-24)

## What Are We Doing Here

Building and hosting image on WPE docker hub, then calling the hosted image instead of building it every time. 


**Original: Avg 11-14 seconds**
(Build Docker Container on the fly)
![cicd-24-docker-container-build-v3-1-1](https://user-images.githubusercontent.com/26469099/184686846-4a2b80c2-d7b9-4b1f-ad82-fa20c3dfe14c.png)

**New: 4 seconds :tada:** 
(Build Docker Container from Hosted Docker Image)
![cicd-24-docker-container-build-cicd-24-branch](https://user-images.githubusercontent.com/26469099/184686847-4882c690-57f5-4a6f-99ac-e6214ddb6dcf.png)

**NewNew: 1 second 🐎**
(Pull Docker Image directly from within action.yml)
![cicd-24-load-docker-image-directly](https://user-images.githubusercontent.com/26469099/184727267-347a840c-eca7-4dcf-90ec-f6d23250bff5.png)

**New SPLIT: 4 seconds ⏩**
(Build Docker Container from Hosted Docker Image, but split to add in exclude.txt and entrypoint script afterwards)
![cicd-24-docker-stable-image](https://user-images.githubusercontent.com/26469099/187735640-1d0bb3fc-6236-4b80-a793-1942ff614fc4.png)



# Plan Moving Forward:
- We're going forward with the "Split" image approach - where base-stable is hosted in Dockerhub and imported as a directive into the main Dockerfile for the project. Additional directives and other frequently updated file inclusion are added below the image.  

## TO DO:
- [ ]  Automate rebuilding the base-image
*  Restore the DockerHub Build Rules

- [ ] Automate building custom images on the fly based on branch name with regex
*  See ideas in the DockerHub Build Rules

- [ ] Optimize the Base Image
