### PR TITLE
Update examples to use actions/checkout@v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: GitHub Action Deploy to WP Engine
       uses: wpengine/github-action-wpe-site-deploy@v3
       with:
@@ -73,7 +73,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: GitHub Action Deploy to WP Engine
       uses: wpengine/github-action-wpe-site-deploy@v3
       with:


### PR DESCRIPTION
# JIRA Ticket

n/a

## What Are We Doing Here

Resolves #69

Updates README examples to use the latest version of `actions/checkout`. The new version [uses the node16 runtime by default](https://github.com/actions/checkout/releases/tag/v3.0.0), which addresses the deprecation warnings mentioned in #69.
