### PR TITLE
[CICD-190] Replace deprecated set output command

### DIFF
--- a/.github/actions/get-release-notes/action.yml
+++ b/.github/actions/get-release-notes/action.yml
@@ -20,5 +20,5 @@ runs:
           notes="${notes//'%'/'%25'}"
           notes="${notes//$'\n'/'%0A'}"
           notes="${notes//$'\r'/'%0D'}"
-          echo "::set-output name=RELEASE_NOTES::$notes"
+          echo "RELEASE_NOTES=$notes" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/publish/publish.sh
+++ b/.github/actions/publish/publish.sh
@@ -59,4 +59,4 @@ for tag in "${tagsToUpdate[@]}"; do
     git push origin "$tag" --force
 done
 
-echo "::set-output name=PUBLISHED::$PUBLISHED"
+echo "PUBLISHED=$PUBLISHED" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -49,6 +49,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: status-github-action
+          # Channel: status-github-action
+          channel_id: C03QDL9U0TW
           status: FAILED
           color: danger

--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -13,14 +13,11 @@ on:
 jobs:
   run_action:
     runs-on: ubuntu-latest
-    outputs:
-      status: ${{ steps.deploy.outputs.status }}
     steps:
       - uses: actions/checkout@v3
       - name: Bump test plugin version number
         run: sed -i 's/0.0.1/0.0.2/' tests/data/plugins/test-plugin/test-plugin.php
       - name: GitHub Action Deploy to WP Engine
-        id: deploy
         uses: ./
         with:
           # Deploy vars
@@ -33,15 +30,21 @@ jobs:
           FLAGS: -r --backup --backup-dir=/tmp --itemize-changes
           SCRIPT: "tests/data/post-deploy/test-plugin.sh"
           CACHE_CLEAR: true
-  validate_result:
-    runs-on: ubuntu-latest
-    needs: run_action
-    steps:
+      - name: Fetch deploy results
+        id: fetchResult
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: "https://ghae2e.wpengine.com/wp-content/plugins/test-plugin/status.json"
       - name: Validate deploy results
         run: |
-          [ ${{needs.run_action.outputs.status}} = "pass" ] || exit 1
+          [ ${{ fromJson(steps.fetchResult.outputs.response).status }} = "success" ] || exit 1
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    needs: run_action
+    steps:
       - name: Notify slack on failure
-        if: failure() && github.ref == 'refs/heads/main'
+        if: needs.run_action.result == 'failure' && github.ref == 'refs/heads/main'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get current version
         id: version
-        run: echo "::set-output name=CURRENT_VERSION::$(node -p "require('./package.json').version")"
+        run: echo "CURRENT_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
   release:
     name: Release

--- a/tests/data/post-deploy/test-plugin.sh
+++ b/tests/data/post-deploy/test-plugin.sh
@@ -3,6 +3,7 @@
 BACKUP_DIR=/tmp
 PLUGINS_DIR=wp-content/plugins
 PLUGIN_NAME=test-plugin
+STATUS_FILE=status.json
 
 cleanup() {
     rm tests/data/post-deploy/test-plugin.sh
@@ -25,8 +26,8 @@ echo "Old test plugin version: $BEFORE_PLUGIN_VERSION"
 # Check that the expected update was made
 if [ -z "$BEFORE_PLUGIN_VERSION" ] || [ -z "$AFTER_PLUGIN_VERSION" ] || [ "$BEFORE_PLUGIN_VERSION" = "$AFTER_PLUGIN_VERSION" ]; then
     echo "Failure: Test plugin was not updated!"
-    echo "::set-output name=status::fail"
+    echo "{\"status\": \"failure\"}" > $PLUGINS_DIR/$PLUGIN_NAME/$STATUS_FILE
 else
     echo "Success: Test plugin successfully updated from $BEFORE_PLUGIN_VERSION to $AFTER_PLUGIN_VERSION!"
-    echo "::set-output name=status::pass"
+    echo "{\"status\": \"success\"}" > $PLUGINS_DIR/$PLUGIN_NAME/$STATUS_FILE
 fi


### PR DESCRIPTION
# JIRA Ticket

[CICD-190](https://wpengine.atlassian.net/browse/CICD-190)

## What Are We Doing Here

The `set-output` command is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This replaces all instances of `set-output` in our workflows.

Looking at each commit might make this easier to review.

Part 1: d3a4afc1efedbdf4334c7d47c9289e3ddd6f5fca - Places where the recommended alternative to `set-output` was a drop-in replacement.
Part 2: ce6a3f8604a9065a4f0b7b452689355f931c5194 - Refactors an instance where the drop-in replacement wouldn't work.


[CICD-190]: https://wpengine.atlassian.net/browse/CICD-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ