### PR TITLE
[CICD-381] Bump @changesets/cli > 2.26.2 (resolve semver vuln)

### DIFF
--- a/.changeset/orange-trees-bow.md
+++ b/.changeset/orange-trees-bow.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/github-action-wpe-site-deploy": patch
+---
+
+Bump @changesets/cli > 2.26.2 (resolves semver vulnerability)

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@wpengine/github-action-wpe-site-deploy",
-  "version": "3.0.0",
+  "version": "3.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wpengine/github-action-wpe-site-deploy",
-      "version": "3.0.0",
+      "version": "3.2.3",
       "devDependencies": {
-        "@changesets/cli": "^2.24.1"
+        "@changesets/cli": "^2.26.2"
       },
       "engines": {
         "node": ">=16",
@@ -51,84 +51,150 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "dev": true,
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.0.3.tgz",
-      "integrity": "sha512-/3JKqtDefs2YSEQI6JQo43/MKTLfhPdrW/BFmqnRpW8UmPB+YXjjQgfjR/2KOaObLOkoixcL3WCK4wNkn/Krmw==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.4.tgz",
+      "integrity": "sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/config": "^2.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/config": "^2.3.1",
         "@changesets/get-version-range-type": "^0.3.2",
-        "@changesets/git": "^1.4.1",
-        "@changesets/types": "^5.1.0",
+        "@changesets/git": "^2.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "detect-indent": "^6.0.0",
         "fs-extra": "^7.0.1",
         "lodash.startcase": "^4.4.0",
         "outdent": "^0.5.0",
-        "prettier": "^1.19.1",
+        "prettier": "^2.7.1",
         "resolve-from": "^5.0.0",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
       }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.0.tgz",
-      "integrity": "sha512-ewY24PEbSec2eKX0+KM7eyENA2hUUp6s4LF9p/iBxTtc+TX2Xbx5rZnlLKZkc8tpuQ3PZbyjLFXWhd1PP6SjCg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.4.tgz",
+      "integrity": "sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.3",
-        "@changesets/types": "^5.1.0",
+        "@changesets/get-dependents-graph": "^1.3.6",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
       }
     },
-    "node_modules/@changesets/changelog-git": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.12.tgz",
-      "integrity": "sha512-Xv2CPjTBmwjl8l4ZyQ3xrsXZMq8WafPUpEonDpTmcb24XY8keVzt7ZSCJuDz035EiqrjmDKDhODoQ6XiHudlig==",
+    "node_modules/@changesets/assemble-release-plan/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "dependencies": {
-        "@changesets/types": "^5.1.0"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@changesets/changelog-git": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.14.tgz",
+      "integrity": "sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==",
+      "dev": true,
+      "dependencies": {
+        "@changesets/types": "^5.2.1"
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.24.1",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.24.1.tgz",
-      "integrity": "sha512-7Lz1inqGQjBrXgnXlENtzQ7EmO/9c+09d9oi8XoK4ARqlJe8GpafjqKRobcjcA/TTI7Fn2+cke4CrXFZfVF8Rw==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.2.tgz",
+      "integrity": "sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/apply-release-plan": "^6.0.3",
-        "@changesets/assemble-release-plan": "^5.2.0",
-        "@changesets/changelog-git": "^0.1.12",
-        "@changesets/config": "^2.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/apply-release-plan": "^6.1.4",
+        "@changesets/assemble-release-plan": "^5.2.4",
+        "@changesets/changelog-git": "^0.1.14",
+        "@changesets/config": "^2.3.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.3",
-        "@changesets/get-release-plan": "^3.0.12",
-        "@changesets/git": "^1.4.1",
+        "@changesets/get-dependents-graph": "^1.3.6",
+        "@changesets/get-release-plan": "^3.0.17",
+        "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
-        "@changesets/pre": "^1.0.12",
-        "@changesets/read": "^0.5.7",
-        "@changesets/types": "^5.1.0",
-        "@changesets/write": "^0.1.9",
+        "@changesets/pre": "^1.0.14",
+        "@changesets/read": "^0.5.9",
+        "@changesets/types": "^5.2.1",
+        "@changesets/write": "^0.2.3",
         "@manypkg/get-packages": "^1.1.3",
         "@types/is-ci": "^3.0.0",
-        "@types/semver": "^6.0.0",
+        "@types/semver": "^7.5.0",
         "ansi-colors": "^4.1.3",
         "chalk": "^2.1.0",
         "enquirer": "^2.3.0",
@@ -141,7 +207,7 @@
         "p-limit": "^2.2.0",
         "preferred-pm": "^3.0.0",
         "resolve-from": "^5.0.0",
-        "semver": "^5.4.1",
+        "semver": "^7.5.3",
         "spawndamnit": "^2.0.0",
         "term-size": "^2.1.0",
         "tty-table": "^4.1.5"
@@ -150,16 +216,49 @@
         "changeset": "bin.js"
       }
     },
+    "node_modules/@changesets/cli/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@changesets/config": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.1.0.tgz",
-      "integrity": "sha512-43potf+DwYHmH7EY19vxtCq6fqj7UUIrZ4DTwM3pVBqCKxFIytm7GPy7wNAsH06UvMw7NRuOu4QK5HN02GsIrw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.1.tgz",
+      "integrity": "sha512-PQXaJl82CfIXddUOppj4zWu+987GCw2M+eQcOepxN5s+kvnsZOwjEJO3DH9eVy+OP6Pg/KFEWdsECFEYTtbg6w==",
       "dev": true,
       "dependencies": {
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.3",
+        "@changesets/get-dependents-graph": "^1.3.6",
         "@changesets/logger": "^0.0.5",
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
         "micromatch": "^4.0.2"
@@ -175,30 +274,63 @@
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.3.tgz",
-      "integrity": "sha512-h4fHEIt6X+zbxdcznt1e8QD7xgsXRAXd2qzLlyxoRDFSa6SxJrDAUyh7ZUNdhjBU4Byvp4+6acVWVgzmTy4UNQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.6.tgz",
+      "integrity": "sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==",
       "dev": true,
       "dependencies": {
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
       }
     },
-    "node_modules/@changesets/get-release-plan": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.12.tgz",
-      "integrity": "sha512-TlpEdpxV5ZQmNeHoD6KNKAc01wjRrcu9/CQqzmO4qAlX7ARA4pIuAxd8QZ1AQXv/l4qhHox7SUYH3VLHfarv5w==",
+    "node_modules/@changesets/get-dependents-graph/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/assemble-release-plan": "^5.2.0",
-        "@changesets/config": "^2.1.0",
-        "@changesets/pre": "^1.0.12",
-        "@changesets/read": "^0.5.7",
-        "@changesets/types": "^5.1.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@changesets/get-release-plan": {
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.17.tgz",
+      "integrity": "sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.20.1",
+        "@changesets/assemble-release-plan": "^5.2.4",
+        "@changesets/config": "^2.3.1",
+        "@changesets/pre": "^1.0.14",
+        "@changesets/read": "^0.5.9",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3"
       }
     },
@@ -209,16 +341,17 @@
       "dev": true
     },
     "node_modules/@changesets/git": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-1.4.1.tgz",
-      "integrity": "sha512-GWwRXEqBsQ3nEYcyvY/u2xUK86EKAevSoKV/IhELoZ13caZ1A1TSak/71vyKILtzuLnFPk5mepP5HjBxr7lZ9Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
+      "integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.2",
         "spawndamnit": "^2.0.0"
       }
     },
@@ -232,61 +365,61 @@
       }
     },
     "node_modules/@changesets/parse": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.14.tgz",
-      "integrity": "sha512-SWnNVyC9vz61ueTbuxvA6b4HXcSx2iaWr2VEa37lPg1Vw+cEyQp7lOB219P7uow1xFfdtIEEsxbzXnqLAAaY8w==",
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
+      "integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
       "dev": true,
       "dependencies": {
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "js-yaml": "^3.13.1"
       }
     },
     "node_modules/@changesets/pre": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.12.tgz",
-      "integrity": "sha512-RFzWYBZx56MtgMesXjxx7ymyI829/rcIw/41hvz3VJPnY8mDscN7RJyYu7Xm7vts2Fcd+SRcO0T/Ws3I1/6J7g==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
+      "integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1"
       }
     },
     "node_modules/@changesets/read": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.7.tgz",
-      "integrity": "sha512-Iteg0ccTPpkJ+qFzY97k7qqdVE5Kz30TqPo9GibpBk2g8tcLFUqf+Qd0iXPLcyhUZpPL1U6Hia1gINHNKIKx4g==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
+      "integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/git": "^1.4.1",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
-        "@changesets/parse": "^0.3.14",
-        "@changesets/types": "^5.1.0",
+        "@changesets/parse": "^0.3.16",
+        "@changesets/types": "^5.2.1",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
         "p-filter": "^2.1.0"
       }
     },
     "node_modules/@changesets/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-uUByGATZCdaPkaO9JkBsgGDjEvHyY2Sb0e/J23+cwxBi5h0fxpLF/HObggO/Fw8T2nxK6zDfJbPsdQt5RwYFJA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.2.1.tgz",
+      "integrity": "sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==",
       "dev": true
     },
     "node_modules/@changesets/write": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.1.9.tgz",
-      "integrity": "sha512-E90ZrsrfJVOOQaP3Mm5Xd7uDwBAqq3z5paVEavTHKA8wxi7NAL8CmjgbGxSFuiP7ubnJA2BuHlrdE4z86voGOg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.2.3.tgz",
+      "integrity": "sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/types": "^5.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/types": "^5.2.1",
         "fs-extra": "^7.0.1",
         "human-id": "^1.0.2",
-        "prettier": "^1.19.1"
+        "prettier": "^2.7.1"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -412,9 +545,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
-      "integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "node_modules/ansi-colors": {
@@ -888,9 +1021,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -904,9 +1037,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1180,9 +1313,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -1932,15 +2065,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pseudomap": {
@@ -2057,9 +2193,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "node_modules/regexp.prototype.flags": {
@@ -2160,9 +2296,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -2870,81 +3006,133 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
+      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@changesets/apply-release-plan": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.0.3.tgz",
-      "integrity": "sha512-/3JKqtDefs2YSEQI6JQo43/MKTLfhPdrW/BFmqnRpW8UmPB+YXjjQgfjR/2KOaObLOkoixcL3WCK4wNkn/Krmw==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.4.tgz",
+      "integrity": "sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/config": "^2.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/config": "^2.3.1",
         "@changesets/get-version-range-type": "^0.3.2",
-        "@changesets/git": "^1.4.1",
-        "@changesets/types": "^5.1.0",
+        "@changesets/git": "^2.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "detect-indent": "^6.0.0",
         "fs-extra": "^7.0.1",
         "lodash.startcase": "^4.4.0",
         "outdent": "^0.5.0",
-        "prettier": "^1.19.1",
+        "prettier": "^2.7.1",
         "resolve-from": "^5.0.0",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@changesets/assemble-release-plan": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.0.tgz",
-      "integrity": "sha512-ewY24PEbSec2eKX0+KM7eyENA2hUUp6s4LF9p/iBxTtc+TX2Xbx5rZnlLKZkc8tpuQ3PZbyjLFXWhd1PP6SjCg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.4.tgz",
+      "integrity": "sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.3",
-        "@changesets/types": "^5.1.0",
+        "@changesets/get-dependents-graph": "^1.3.6",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@changesets/changelog-git": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.12.tgz",
-      "integrity": "sha512-Xv2CPjTBmwjl8l4ZyQ3xrsXZMq8WafPUpEonDpTmcb24XY8keVzt7ZSCJuDz035EiqrjmDKDhODoQ6XiHudlig==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.14.tgz",
+      "integrity": "sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==",
       "dev": true,
       "requires": {
-        "@changesets/types": "^5.1.0"
+        "@changesets/types": "^5.2.1"
       }
     },
     "@changesets/cli": {
-      "version": "2.24.1",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.24.1.tgz",
-      "integrity": "sha512-7Lz1inqGQjBrXgnXlENtzQ7EmO/9c+09d9oi8XoK4ARqlJe8GpafjqKRobcjcA/TTI7Fn2+cke4CrXFZfVF8Rw==",
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.2.tgz",
+      "integrity": "sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/apply-release-plan": "^6.0.3",
-        "@changesets/assemble-release-plan": "^5.2.0",
-        "@changesets/changelog-git": "^0.1.12",
-        "@changesets/config": "^2.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/apply-release-plan": "^6.1.4",
+        "@changesets/assemble-release-plan": "^5.2.4",
+        "@changesets/changelog-git": "^0.1.14",
+        "@changesets/config": "^2.3.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.3",
-        "@changesets/get-release-plan": "^3.0.12",
-        "@changesets/git": "^1.4.1",
+        "@changesets/get-dependents-graph": "^1.3.6",
+        "@changesets/get-release-plan": "^3.0.17",
+        "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
-        "@changesets/pre": "^1.0.12",
-        "@changesets/read": "^0.5.7",
-        "@changesets/types": "^5.1.0",
-        "@changesets/write": "^0.1.9",
+        "@changesets/pre": "^1.0.14",
+        "@changesets/read": "^0.5.9",
+        "@changesets/types": "^5.2.1",
+        "@changesets/write": "^0.2.3",
         "@manypkg/get-packages": "^1.1.3",
         "@types/is-ci": "^3.0.0",
-        "@types/semver": "^6.0.0",
+        "@types/semver": "^7.5.0",
         "ansi-colors": "^4.1.3",
         "chalk": "^2.1.0",
         "enquirer": "^2.3.0",
@@ -2957,22 +3145,48 @@
         "p-limit": "^2.2.0",
         "preferred-pm": "^3.0.0",
         "resolve-from": "^5.0.0",
-        "semver": "^5.4.1",
+        "semver": "^7.5.3",
         "spawndamnit": "^2.0.0",
         "term-size": "^2.1.0",
         "tty-table": "^4.1.5"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@changesets/config": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.1.0.tgz",
-      "integrity": "sha512-43potf+DwYHmH7EY19vxtCq6fqj7UUIrZ4DTwM3pVBqCKxFIytm7GPy7wNAsH06UvMw7NRuOu4QK5HN02GsIrw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.1.tgz",
+      "integrity": "sha512-PQXaJl82CfIXddUOppj4zWu+987GCw2M+eQcOepxN5s+kvnsZOwjEJO3DH9eVy+OP6Pg/KFEWdsECFEYTtbg6w==",
       "dev": true,
       "requires": {
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.3",
+        "@changesets/get-dependents-graph": "^1.3.6",
         "@changesets/logger": "^0.0.5",
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
         "micromatch": "^4.0.2"
@@ -2988,30 +3202,56 @@
       }
     },
     "@changesets/get-dependents-graph": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.3.tgz",
-      "integrity": "sha512-h4fHEIt6X+zbxdcznt1e8QD7xgsXRAXd2qzLlyxoRDFSa6SxJrDAUyh7ZUNdhjBU4Byvp4+6acVWVgzmTy4UNQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.6.tgz",
+      "integrity": "sha512-Q/sLgBANmkvUm09GgRsAvEtY3p1/5OCzgBE5vX3vgb5CvW0j7CEljocx5oPXeQSNph6FXulJlXV3Re/v3K3P3Q==",
       "dev": true,
       "requires": {
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
-        "semver": "^5.4.1"
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@changesets/get-release-plan": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.12.tgz",
-      "integrity": "sha512-TlpEdpxV5ZQmNeHoD6KNKAc01wjRrcu9/CQqzmO4qAlX7ARA4pIuAxd8QZ1AQXv/l4qhHox7SUYH3VLHfarv5w==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.17.tgz",
+      "integrity": "sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/assemble-release-plan": "^5.2.0",
-        "@changesets/config": "^2.1.0",
-        "@changesets/pre": "^1.0.12",
-        "@changesets/read": "^0.5.7",
-        "@changesets/types": "^5.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/assemble-release-plan": "^5.2.4",
+        "@changesets/config": "^2.3.1",
+        "@changesets/pre": "^1.0.14",
+        "@changesets/read": "^0.5.9",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3"
       }
     },
@@ -3022,16 +3262,17 @@
       "dev": true
     },
     "@changesets/git": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-1.4.1.tgz",
-      "integrity": "sha512-GWwRXEqBsQ3nEYcyvY/u2xUK86EKAevSoKV/IhELoZ13caZ1A1TSak/71vyKILtzuLnFPk5mepP5HjBxr7lZ9Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
+      "integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.2",
         "spawndamnit": "^2.0.0"
       }
     },
@@ -3045,61 +3286,61 @@
       }
     },
     "@changesets/parse": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.14.tgz",
-      "integrity": "sha512-SWnNVyC9vz61ueTbuxvA6b4HXcSx2iaWr2VEa37lPg1Vw+cEyQp7lOB219P7uow1xFfdtIEEsxbzXnqLAAaY8w==",
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
+      "integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
       "dev": true,
       "requires": {
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "js-yaml": "^3.13.1"
       }
     },
     "@changesets/pre": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.12.tgz",
-      "integrity": "sha512-RFzWYBZx56MtgMesXjxx7ymyI829/rcIw/41hvz3VJPnY8mDscN7RJyYu7Xm7vts2Fcd+SRcO0T/Ws3I1/6J7g==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
+      "integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.1.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1"
       }
     },
     "@changesets/read": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.7.tgz",
-      "integrity": "sha512-Iteg0ccTPpkJ+qFzY97k7qqdVE5Kz30TqPo9GibpBk2g8tcLFUqf+Qd0iXPLcyhUZpPL1U6Hia1gINHNKIKx4g==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
+      "integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/git": "^1.4.1",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
-        "@changesets/parse": "^0.3.14",
-        "@changesets/types": "^5.1.0",
+        "@changesets/parse": "^0.3.16",
+        "@changesets/types": "^5.2.1",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
         "p-filter": "^2.1.0"
       }
     },
     "@changesets/types": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-uUByGATZCdaPkaO9JkBsgGDjEvHyY2Sb0e/J23+cwxBi5h0fxpLF/HObggO/Fw8T2nxK6zDfJbPsdQt5RwYFJA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.2.1.tgz",
+      "integrity": "sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==",
       "dev": true
     },
     "@changesets/write": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.1.9.tgz",
-      "integrity": "sha512-E90ZrsrfJVOOQaP3Mm5Xd7uDwBAqq3z5paVEavTHKA8wxi7NAL8CmjgbGxSFuiP7ubnJA2BuHlrdE4z86voGOg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.2.3.tgz",
+      "integrity": "sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/types": "^5.1.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/types": "^5.2.1",
         "fs-extra": "^7.0.1",
         "human-id": "^1.0.2",
-        "prettier": "^1.19.1"
+        "prettier": "^2.7.1"
       }
     },
     "@manypkg/find-root": {
@@ -3214,9 +3455,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
-      "integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
     },
     "ansi-colors": {
@@ -3592,9 +3833,9 @@
       }
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3605,9 +3846,9 @@
       }
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -3812,9 +4053,9 @@
       }
     },
     "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
     "indent-string": {
@@ -4347,9 +4588,9 @@
       }
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pseudomap": {
@@ -4432,9 +4673,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "dev": true
     },
     "regexp.prototype.flags": {
@@ -4499,9 +4740,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@changesets/cli": "^2.24.1"
+    "@changesets/cli": "^2.26.2"
   }
 }


### PR DESCRIPTION
# JIRA Ticket

[CICD-381](https://wpengine.atlassian.net/browse/CICD-381)

## What Are We Doing Here

Here is where you should describe the problem you are solving, adding any fine details on the solution that might
otherwise not be recognizable for someone unfamiliar with the changes. Add some pictures if it helps.

Bump @changesets/cli > 2.26.2  to resolve the [semver vulnerability](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)

> 
> Versions of the package semver before 7.5.2 on the 7.x branch, before 6.3.1 on the 6.x branch, and all other versions before 5.7.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.
> 
> **Patched versions**
> 7.5.2
> 6.3.1
> 5.7.2


[CICD-381]: https://wpengine.atlassian.net/browse/CICD-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ