### PR TITLE
[CICD-398] Update exclude.txt link

### DIFF
--- a/.changeset/empty-stingrays-tie.md
+++ b/.changeset/empty-stingrays-tie.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/github-action-wpe-site-deploy": patch
+---
+
+Update link to exclude.txt

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ jobs:
 * [Defining environment variables in GitHub Actions](https://docs.github.com/en/actions/reference/environment-variables)
 * [Storing secrets in GitHub repositories](https://docs.github.com/en/actions/reference/encrypted-secrets)
 * It is recommended to leverage one of [WP Engine's .gitignore templates.](https://wpengine.com/support/git/#Add_gitignore?utm_content=wpe_gha)
-* This action excludes several files and directories from the deploy by default. See the [exclude.txt](https://github.com/wpengine/github-action-wpe-site-deploy/blob/main/exclude.txt) for reference.
+* This action excludes several files and directories from the deploy by default. See the [exclude.txt](https://github.com/wpengine/site-deploy/blob/main/exclude.txt) for reference.
 
 ## Versioning
 


### PR DESCRIPTION
# JIRA Ticket

[CICD-398](https://wpengine.atlassian.net/browse/CICD-398)

## What Are We Doing Here

Here is where you should describe the problem you are solving, adding any fine details on the solution that might
otherwise not be recognizable for someone unfamiliar with the changes. Add some pictures if it helps.

Updating link to the exclude.txt, which was moved to https://github.com/wpengine/site-deploy/blob/main/exclude.txt


[CICD-398]: https://wpengine.atlassian.net/browse/CICD-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ