### PR TITLE
[CICD-757] Bump site deploy image version

### DIFF
--- a/.changeset/yellow-cows-live.md
+++ b/.changeset/yellow-cows-live.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/github-action-wpe-site-deploy": patch
+---
+
+Update wpengine/site-deploy image to 1.0.3

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://wpengine/site-deploy:1.0.2
+  image: docker://wpengine/site-deploy:1.0.3
   env:
     WPE_SSHG_KEY_PRIVATE: ${{ inputs.WPE_SSHG_KEY_PRIVATE }}
     WPE_ENV: ${{ inputs.WPE_ENV }}


### PR DESCRIPTION
# JIRA Ticket

[CICD-757](https://wpengine.atlassian.net/browse/CICD-757)

## What Are We Doing Here

Bump site deploy image version to 1.0.3.


[CICD-757]: https://wpengine.atlassian.net/browse/CICD-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ