### PR TITLE
Update FLAGS formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ jobs:
         SRC_PATH: "wp-content/themes/genesis-child-theme/"
         REMOTE_PATH: "wp-content/themes/genesis-child-theme/"
         PHP_LINT: TRUE
-        FLAGS: -azvr --inplace --delete --exclude=".*"  --exclude=wp-content/mu-plugins/local-plugin --exclude-from=ignorefile.txt
+        FLAGS: -azvr --inplace --delete --exclude=".*"  --exclude=wp-content/mu-plugins/local-plugin --exclude-from=.deployignore
         SCRIPT: "path/yourscript.sh"
         CACHE_CLEAR: TRUE
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ jobs:
         SRC_PATH: "wp-content/themes/genesis-child-theme/"
         REMOTE_PATH: "wp-content/themes/genesis-child-theme/"
         PHP_LINT: TRUE
-        FLAGS: -azvr --inplace --delete --exclude=".*"  --exclude=wp-content/mu-plugins/local-plugin --exclude-from=.deployignore
+        FLAGS: -azvr --inplace --delete --exclude=.*  --exclude=wp-content/mu-plugins/local-plugin --exclude-from=.deployignore
         SCRIPT: "path/yourscript.sh"
         CACHE_CLEAR: TRUE
 ```


### PR DESCRIPTION
# JIRA Ticket

N/A

## What Are We Doing Here

A couple of small updates to our Extended main.yml example.

1. Changed `--exclude-from=ignorefile.txt` to `--exclude-from=.deployignore` to match the filename referenced in the Deploy Options > FLAGS description.
2. Changed `--exclude=".*"` to `--exclude=.*`. After some testing done in [this build log](https://github.com/matthewselby/wpe-gitpush/actions/runs/10421612139/job/28864202832#step:4:8) the rsync `--exclude` option needs to be without quotes to be used in our Action Workflow. This also resolves #82 
