### PR TITLE
[CICD-786] Upgrade actions/setup-node to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
 
@@ -57,7 +57,7 @@ jobs:
           git config user.email github-actions[bot]@users.noreply.github.com
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
 


### PR DESCRIPTION
# JIRA Ticket

[CICD-786](https://wpengine.atlassian.net/browse/CICD-786)

## What Are We Doing Here

Upgrade action/setup-node to v4 for better Node 20 support (setup-node@v4 natively uses Node 20).


[CICD-786]: https://wpengine.atlassian.net/browse/CICD-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ