### PR TITLE
[CICD-817] update cron

### DIFF
--- a/.github/workflows/e2e-deploy.yml
+++ b/.github/workflows/e2e-deploy.yml
@@ -1,7 +1,7 @@
 name: Test e2e Deploy to WP Engine
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/60 * * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
## What Are We Doing Here

Dropping the e2e deploy test run to go once an hour. aka in Cron “At every 60th minute.”

