### PR TITLE
Update README to address quote usage in FLAGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
     - name: GitHub Action Deploy to WP Engine
       uses: wpengine/github-action-wpe-site-deploy@v3
       with:
-      # Deploy vars
+        # Deploy vars
         WPE_SSHG_KEY_PRIVATE: ${{ secrets.WPE_SSHG_KEY_PRIVATE }}
         WPE_ENV: <your_install_name_here>
         # Deploy Options
@@ -105,7 +105,7 @@ jobs:
 | `SRC_PATH` | string | Optional path to specify a directory within the repo to deploy from. Ex. `"wp-content/themes/genesis-child-theme/"`. Defaults to root of repo filesystem as source. |
 | `REMOTE_PATH` | string | Optional path to specify a directory destination to deploy to. Ex. `"wp-content/themes/genesis-child-theme/"` . Defaults to WordPress root directory on WP Engine.  |
 | `PHP_LINT` | bool | Set to TRUE to execute a php lint on your branch pre-deployment. Default is `FALSE`. |
-| `FLAGS` | string | Set optional rsync flags such as `--delete` or `--exclude-from`. The example is excluding paths specified in a `.deployignore` file in the root of the repo. This action defaults to a non-destructive deploy using the flags in the example above. <br /><br />_Caution: Setting custom rsync flags replaces the default flags provided by this action. Consider also adding the `-azvr` flags as needed.<br /> `-a` preserves symbolic links, timestamps, user permissions and ownership.<br /> `-z` is for compression <br /> `-v` is for verbose output<br /> `-r` is for recursive directory scanning_|
+| `FLAGS` | string | Set optional rsync flags such as `--delete` or `--exclude-from`. The extended example above is excluding paths specified in a `.deployignore` file in the root of the repo. This action defaults to a non-destructive deploy.<br /><br />For flags that contain whitespace, use single quotes around the flag's value:<br /><br />`FLAGS: -azvr --filter=':- .gitignore'`<br /><br /> For flags that do not contain whitespace, quotes are unnecessary.<br /><br /> **Default:** `-azvr --inplace --exclude=.*` <br /><br />_Caution: Setting custom rsync flags replaces the default flags provided by this action. Consider also adding the `-azvr` flags as needed.<br /> `-a` preserves symbolic links, timestamps, user permissions and ownership.<br /> `-z` is for compression <br /> `-v` is for verbose output<br /> `-r` is for recursive directory scanning_|
 | `SCRIPT` | string | Remote bash file to execute post-deploy. This can include WP_CLI commands for example. Path is relative to the WP root and file executes on remote. This file can be included in your repo, or be a persistent file that lives on your server.  |
 | `CACHE_CLEAR` | bool | Optionally clear page and CDN cache post deploy. This takes a few seconds. Default is TRUE. |
 


### PR DESCRIPTION
# JIRA Ticket

n/a

## What Are We Doing Here

Add additional documentation regarding quote usage in the FLAGS variable. Relates to the work that was done to fix flag parsing in https://github.com/wpengine/site-deploy/pull/32.
