### PR TITLE
[CICD-761] Bump wpengine/site-deploy to version 1.0.5

### DIFF
--- a/.changeset/nice-fans-buy.md
+++ b/.changeset/nice-fans-buy.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/github-action-wpe-site-deploy": patch
+---
+
+Bump wpengine/site-deploy image version [1.0.5](https://github.com/wpengine/site-deploy/releases/tag/v1.0.5)

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://wpengine/site-deploy:1.0.4
+  image: docker://wpengine/site-deploy:1.0.5
   env:
     WPE_SSHG_KEY_PRIVATE: ${{ inputs.WPE_SSHG_KEY_PRIVATE }}
     WPE_ENV: ${{ inputs.WPE_ENV }}


### PR DESCRIPTION
# JIRA Ticket

[CICD-761](https://wpengine.atlassian.net/browse/CICD-761)

## What Are We Doing Here

Fixes #91

Default exclude rules are now dynamically generated relative to `REMOTE_PATH`, if provided.

Implemented by https://github.com/wpengine/site-deploy/pull/42

[CICD-761]: https://wpengine.atlassian.net/browse/CICD-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ