### PR TITLE
[CICD-892] Bump wpengine/site-deploy to version 1.0.6

### DIFF
--- a/.changeset/great-tigers-brake.md
+++ b/.changeset/great-tigers-brake.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/github-action-wpe-site-deploy": patch
+---
+
+Bump wpengine/site-deploy image version [1.0.6](https://github.com/wpengine/site-deploy/releases/tag/v1.0.6)

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
 
 runs:
   using: "docker"
-  image: docker://wpengine/site-deploy:1.0.5
+  image: docker://wpengine/site-deploy:1.0.6
   env:
     WPE_SSHG_KEY_PRIVATE: ${{ inputs.WPE_SSHG_KEY_PRIVATE }}
     WPE_ENV: ${{ inputs.WPE_ENV }}


### PR DESCRIPTION
# JIRA Ticket

[CICD-892](https://wpengine.atlassian.net/browse/CICD-892)

## What Are We Doing Here

A new mu-plugin needs to be excluded from deploys. Implemented by https://github.com/wpengine/site-deploy/pull/45.
